### PR TITLE
Colormodel and scalar/span reduction support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-tags
-tags.*
-
+# Python
 __pycache__/
 *.egg-info/
+
+# General
+*.log
+*.json
 

--- a/src/api/change_basis.py
+++ b/src/api/change_basis.py
@@ -1,0 +1,21 @@
+from colorsys import rgb_to_hls
+
+
+def change_basis(rgb: tuple[float], colormodel: str, scalars: [str]):
+    '''
+    Takes an `rgb` color changes it to the specified `colormodel`, then reduces
+    its span to the `scalars` specified
+    '''
+    if (len(rgb) != len(colormodel)):
+        raise Exception("Provided color and colormodel must be of the same size.")
+
+    color = rgb
+
+    if (colormodel == 'hls'):
+        color = rgb_to_hls(*color)
+
+    if (scalars):
+        color = list(zip(*filter(lambda x: x[0] in scalars, zip(colormodel, color))))[1]
+
+    return color
+

--- a/src/api/descriptor.py
+++ b/src/api/descriptor.py
@@ -5,7 +5,7 @@ from sys import stderr
 
 
 # TODO SemVer
-DESCRIPTOR_VERSION = '0.1.0'
+DESCRIPTOR_VERSION = '0.1.1'
 
 class DescriptorJSONEncoder(JSONEncoder):
     def default(self, o):
@@ -27,6 +27,9 @@ class Descriptor():
     resolvers: list[tuple[tuple[int, int], tuple[int, int]]]
     pick_delay: float
     expected_pick: tuple[tuple[int, int], tuple[int, int]]
+    colormodel: str
+    scalars: [str]
+    variance: float
     version: str = DESCRIPTOR_VERSION
 
     @staticmethod

--- a/src/api/detect.py
+++ b/src/api/detect.py
@@ -1,25 +1,23 @@
-import gi
-gi.require_version('Gdk', '3.0')
-from gi.repository import Gdk
+from .change_basis import change_basis
+from .pick import pick
+from .variance import variance
 
-from api.variance import variance
-
-# TODO Add param "transform", which will transform the pixbuf's pixels to
-# something compatible with typeof color
-def detect(pos, color, _variance=0):
+def detect(pos, color, colormodel='rgb', scalars=[], allowed_variance=0):
     '''
     Detects the colored pixel at the given location. A tolerance can be
     provided as well as a timeout. This function is blocking.
 
     pos := (x, y) position of the screen
     color: = (r, g, b) color of the pixel
-    _variance := maximum allowed color variance where variance is the square of
+    colormodel := The colormodel which to detect the pixel in
+    scalars := The scalars which to take into account when detecting the pixel
+    allowed_variance := maximum allowed color variance where variance is the square of
                  the Euclidean distance between two colors.
 
     '''
+    color = change_basis(color, colormodel, scalars)
     while True:
-        pixbuf = Gdk.pixbuf_get_from_window(Gdk.get_default_root_window(), pos[0], pos[1], 1, 1)
-        c = tuple(pixbuf.get_pixels())
-        if (variance(c, color) <= _variance):
+        c = change_basis(pick(*pos), colormodel, scalars)
+        if (variance(c, color) <= allowed_variance):
             break
 

--- a/src/api/pick.py
+++ b/src/api/pick.py
@@ -1,28 +1,28 @@
 import gi
 gi.require_version('Gdk', '3.0')
 from gi.repository import Gdk
-from pynput.mouse import Listener as MouseListener
+import logging
+from sys import stderr
+from time import perf_counter
 
-# TODO Make this non-blocking and replace. All the other functions should not
-# need to do this Gdk.pixbuf thing
-def pick():
+
+logging.basicConfig(filename='api-pick.log', level=logging.INFO)
+
+def pick(x, y) -> tuple[int, int, int]:
     '''
     On click, return ((x,y), (r, g, b)) where (r, g, b) is
     the color of the pixel at position (x, y) on the screen.
     This function is blocking.
     '''
-    ret = []
-    def _selectColor(x, y, button, pressed):
-        pixbuf = Gdk.pixbuf_get_from_window(Gdk.get_default_root_window(), x, y, 1, 1)
-        ret.append(((x, y), tuple(pixbuf.get_pixels()),))
-        return False
+    start = perf_counter()
+    pixbuf = Gdk.pixbuf_get_from_window(Gdk.get_default_root_window(), x, y, 1, 1)
+    end = perf_counter()
+    logging.info(f'Pixel capture took {end-start}')
+    return _normalize(tuple(pixbuf.get_pixels()), 2**pixbuf.get_bits_per_sample()-1)
 
-    with MouseListener(
-        on_click=_selectColor
-    ) as l:
-        l.join()
-        if (len(ret) > 0):
-            return ret[0]
-        else:
-            return None
+def _normalize(l, m):
+    '''
+    Return copy of l normalized to m
+    '''
+    return tuple([x/m for x in l])
 

--- a/src/api/variance.py
+++ b/src/api/variance.py
@@ -1,8 +1,10 @@
+from scipy.spatial.distance import euclidean
+
 # TODO The params should have the same dimensions but this function should
 # not depend on the actual number of them
 def variance(a, b):
     '''
     Takes finds the Euclidean distance between two points
     '''
-    return (b[0]-a[0])**2 + (b[1]-a[1])**2 + (b[2]-a[2])**2
+    return euclidean(a, b)
 

--- a/src/cli/detect.py
+++ b/src/cli/detect.py
@@ -5,8 +5,8 @@ from api.detect import detect as aDetect
 
 @click.command(help='Detect color at screen position')
 @click.option('--pos', type=int, nargs=2, required=True, help='x y position for pixel on screen.')
-@click.option('--color', type=int, nargs=3, required=True, help='r g b color for pixel.')
-@click.option('--variance', type=int, default=0, help='Allowed color variance.')
+@click.option('--color', type=float, nargs=3, required=True, help='r g b color for pixel.')
+@click.option('--variance', type=float, default=0, help='Allowed color variance.')
 def detect(pos, color, variance):
     click.echo('Waiting...')
     thread = Thread(target=aDetect, args=(pos, color, variance))

--- a/src/cli/execute.py
+++ b/src/cli/execute.py
@@ -1,9 +1,5 @@
 from time import sleep
 import click
-import gi
-
-gi.require_version('Gdk', '3.0')
-from gi.repository import Gdk
 
 from api.descriptor import Descriptor
 from api.detect import detect
@@ -11,13 +7,30 @@ from api.pick import pick
 from api.variance import variance as aVariance
 
 
-@click.option('--identifier_variance', type=int, default=1000, show_default=True, help='Allowed color variance. NOT IMPLEMENTED.')
-@click.option('--shiny_variance', type=int, default=1000, show_default=True, help='Allowed color variance. NOT IMPLEMENTED.')
+@click.option('--variance', type=float, help='Override the descriptor color variance by setting this.')
+@click.option('--colormodel',
+              type=click.Choice(['rgb', 'hls']),
+              help='Override the descriptor colormodel by setting this.')
+@click.option('--scalar', 'scalars',
+              type=str,
+              default=[],
+              multiple=True,
+              help='Override the descriptor scalars by setting these.')
 @click.option('--debounce', type=int, default=0, help='Second to debounce the identifier resolver after a (non)shiny pick')
 @click.argument('file', default='-', type=click.File('r'))
 @click.command(help='Records a shiny detector package. Saves to file.')
-def execute(identifier_variance, shiny_variance, debounce, file):
+def execute(variance, colormodel, scalars, debounce, file):
     descriptor = Descriptor.from_json(file.read())
+
+    # CLI overrides
+    if variance is not None:
+        descriptor.variance = variance
+
+    if colormodel is not None:
+        descriptor.colormodel = colormodel
+
+    if scalars is not None:
+        descriptor.scalars = scalars
 
     resets = 0
     found = False
@@ -26,17 +39,16 @@ def execute(identifier_variance, shiny_variance, debounce, file):
         click.echo('Resolving identifers...')
         for i in descriptor.resolvers:
             pos, color = i
-            detect(pos, color, _variance=identifier_variance)
+            detect(pos, color, descriptor.colormodel, descriptor.scalars, descriptor.variance)
 
         click.echo('Delaying for shiny pick...')
         sleep(descriptor.pick_delay)
 
         shiny_loc, shiny_color = descriptor.expected_pick
-        pixbuf = Gdk.pixbuf_get_from_window(Gdk.get_default_root_window(), shiny_loc[0], shiny_loc[1], 1, 1)
-        picked_color = tuple(pixbuf.get_pixels())
+        picked_color = pick(*shiny_loc)
 
-        click.echo(f'Picked {"#%02x%02x%02x" % picked_color}')
-        if (aVariance(picked_color, shiny_color) >= shiny_variance):
+        click.echo(f'Picked {picked_color}')
+        if (aVariance(picked_color, shiny_color) > descriptor.variance):
             found = True
         else:
             click.echo('Not shiny')

--- a/src/cli/pick.py
+++ b/src/cli/pick.py
@@ -1,32 +1,35 @@
+from colorsys import rgb_to_hls
+from pynput.mouse import Listener as MouseListener
 import click
 
 from api.pick import pick as aPick
 
 @click.command(help='Pick color at screen position')
-@click.option('--cformat',
-              type=click.Choice(['rgb', 'hex', 'hsl', 'hwb', 'cmyk', 'ncol']),
+@click.option('--colormodel',
+              type=click.Choice(['rgb', 'hls']),
               default='rgb',
               show_default=True,
-              help='Print color as hex value')
-def pick(cformat):
+              help='Print color in specific colormodel')
+def pick(colormodel):
     click.echo('Click to pick a color')
-    pos, color = aPick()
 
-    if cformat == 'hex':
-        color = '#%02x%02x%02x' % color
-    elif cformat == 'hsl':
-        # TODO implement
-        pass
-    elif cformat == 'hwb':
-        # TODO implement
-        pass
-    elif cformat == 'cmyk':
-        # TODO implement
-        pass
-    elif cformat == 'ncol':
-        # TODO implement
-        pass
+    color = []
 
-    click.echo(f'position={pos}')
-    click.echo(f'color={color}')
+    def _selectColor(x, y, button, pressed):
+        color.append(aPick(x, y))
+        return False
+
+    with MouseListener(
+        on_click=_selectColor
+    ) as l:
+        l.join()
+
+    if (len(color) > 0):
+        if (colormodel == 'rgb'):
+            click.echo(color[0])
+        elif (colormodel == 'hls'):
+            click.echo(rgb_to_hls(*color[0]))
+
+    else:
+        click.echo('Failed to pick color', err=True)
 

--- a/src/cli/record.py
+++ b/src/cli/record.py
@@ -3,13 +3,8 @@ from pynput.mouse import Listener as MouseListener, Button
 from threading import Thread
 from time import perf_counter
 import click
-import gi
 
 from api.descriptor import Descriptor
-
-gi.require_version('Gdk', '3.0')
-from gi.repository import Gdk
-
 from api.detect import detect
 from api.pick import pick
 
@@ -32,9 +27,12 @@ class IdentifierPicker(Thread):
 
     def _pick(self, x, y, button, pressed):
         if (pressed):
-            pixbuf = Gdk.pixbuf_get_from_window(Gdk.get_default_root_window(), x, y, 1, 1)
-            self.identifiers.append(((x, y), tuple(pixbuf.get_pixels()),))
-            click.echo(f'Picked {"#%02x%02x%02x" % self.identifiers[-1][1]}', err=True)
+            # Always will store the pick as rgb so we can convert it at
+            # execution time. If we change it now, we risk reducing the basis.
+            # For example, if we change it to h(sl), we can't change it back to
+            # rgb since we've already gotten rid of the s and l parts.
+            self.identifiers.append(((x, y), pick(x, y)))
+            click.echo(f'Picked {self.identifiers[-1][1]}', err=True)
             if (button == Button.left):
                 self.finished = True
         return False
@@ -65,10 +63,20 @@ class IdentifierEnder(Thread):
                     break;
 
 
-@click.option('--variance', type=int, default=0, help='Allowed color variance. Used when replaying to get perform shiny pick. NOT IMPLEMENTED.')
+@click.option('--variance', type=float, default=0, help='Allowed color variance. Used when replaying to get perform shiny pick.')
+@click.option('--colormodel',
+              type=click.Choice(['rgb', 'hls']),
+              default='rgb',
+              show_default=True,
+              help='The colormodel at which to compute the variance. An RGB colormodel must still be passed in')
+@click.option('--scalar', 'scalars',
+              type=str,
+              default=[],
+              multiple=True,
+              help='The pieces of the colormodel which to compute the variance. For example, to computer the variance of just hue, use `--colormodel hsl --scalar h`')
 @click.option('--file', type=click.File('w'), default='-', help='Path to file to save descriptor in.')
 @click.command(help='Records a shiny detector package. Saves to file.')
-def record(variance, file):
+def record(variance, colormodel, scalars, file):
     click.echo('Pick at least one identifer. Use right click to select more, left click to select the last one.', err=True)
 
     identifiers = []
@@ -79,13 +87,27 @@ def record(variance, file):
     click.echo('Attempting to resolve identity...', err=True)
     for i in identifiers:
         pos, color = i
-        detect(pos, color)
+        detect(pos, color, colormodel, scalars, variance)
+        click.echo(f'Resolved identifier {i}', err=True)
     start = perf_counter()
     click.echo('Identifiers resolved. Click the shiny color when available.', err=True)
 
-    shiny_pick = pick()
+    expected_color = []
+    expected_pos = []
+    def _selectColor(x, y, button, pressed):
+        expected_pos.append((x, y))
+        expected_color.append(pick(x, y))
+        return False
+
+    with MouseListener(
+        on_click=_selectColor
+    ) as l:
+        l.join()
+
     delay = perf_counter() - start
 
-    descriptor = Descriptor(identifiers, delay, shiny_pick)
+    descriptor = Descriptor(identifiers, delay, (expected_pos[0],
+                                                 expected_color[0]),
+                            colormodel, scalars, variance)
     file.write(descriptor.to_json())
 

--- a/src/cli/util.py
+++ b/src/cli/util.py
@@ -1,0 +1,10 @@
+def verify_scalars(colormodel: str, scalars: [str]) -> bool:
+    '''
+    Takes a colormodel and a list of scalars. It ensures that each scalar
+    exists in the colormodel
+    '''
+    for scalar in scalars:
+        if scalar not in colormodel:
+            return False
+    return True
+

--- a/src/cli/variance.py
+++ b/src/cli/variance.py
@@ -1,13 +1,63 @@
-from PIL import ImageColor
+from ast import literal_eval
+from pynput.mouse import Listener as MouseListener
 import click
 
+from api.change_basis import change_basis
+from api.pick import pick as aPick
 from api.variance import variance as aVariance
 
-@click.command(help='Returns the variance of two colors given as hex colors')
-@click.argument('c1', type=str)
-@click.argument('c2', type=str)
-def variance(c1, c2):
-    c1AsRGB = ImageColor.getcolor(c1, "RGB")
-    c2AsRGB = ImageColor.getcolor(c2, "RGB")
-    click.echo(aVariance(c1AsRGB, c2AsRGB))
+from .util import verify_scalars
+
+
+@click.command(help='Returns the variance of two rgb tuples with normalized values.')
+@click.option('--colormodel',
+              type=click.Choice(['rgb', 'hls']),
+              default='rgb',
+              show_default=True,
+              help='The colormodel at which to compute the variance. An RGB colormodel must still be passed in')
+@click.option('--scalar', 'scalars',
+              type=str,
+              default=[],
+              multiple=True,
+              help='The pieces of the colormodel which to compute the variance. For example, to computer the variance of just hue, use `--colormodel hsl --scalar h`')
+@click.option('--color1', type=str, default='', help='First color to compare. If not populated one will need to be picked at runtime.')
+@click.option('--color2', type=str, default='', help='Second color to compare. If not populated one will need to be picked at runtime.')
+def variance(color1, color2, colormodel, scalars):
+    if color1:
+        color1 = literal_eval(color1)
+    else:
+        color1 = getColor()
+
+    if color2:
+        color2 = literal_eval(color2)
+    else:
+        color2 = getColor()
+
+    if (scalars and not verify_scalars(colormodel, scalars)):
+        click.echo('Invalid scalars provided', err=True)
+        return
+
+    color1 = change_basis(color1, colormodel, scalars)
+    color2 = change_basis(color2, colormodel, scalars)
+
+    click.echo(aVariance(color1, color2))
+
+def getColor():
+    click.echo('Click to pick a color')
+
+    color = []
+
+    def _selectColor(x, y, button, pressed):
+        color.append(aPick(x, y))
+        return False
+
+    with MouseListener(
+        on_click=_selectColor
+    ) as l:
+        l.join()
+
+    if (len(color) > 0):
+        return color[0]
+    else:
+        click.echo('Failed to pick color', err=True)
 


### PR DESCRIPTION
- api pick now takes position instead of being blocking
- api pick returns rgb with scalars between 0 and 1
- added colormodel support
  - added hsl colormodel
- added ability to change span of colormodel
- variance calculations are now independent of the size of vector as
  long as they're the same
- fix ignores
- change_basis function whose job it is to change rgb vectors to a given
  basis and reduce their space given a colormodel scalar specification
- variance arg type can now be floats

Closes #7